### PR TITLE
Change CountryRepository ID type from Long to String

### DIFF
--- a/ch18-rest/ch18-spring-boot-rest/src/main/java/com/manning/junitbook/spring/model/CountryRepository.java
+++ b/ch18-rest/ch18-spring-boot-rest/src/main/java/com/manning/junitbook/spring/model/CountryRepository.java
@@ -22,5 +22,5 @@ package com.manning.junitbook.spring.model;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CountryRepository extends JpaRepository<Country, Long> {
+public interface CountryRepository extends JpaRepository<Country, String> {
 }


### PR DESCRIPTION
According to the declaration of the Country entity, the type of the ID should be String, not Long.